### PR TITLE
Delete default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,0 @@
-let
-  pkgs = import ./nix/pkgs.nix;
-  nix-buildkite = pkgs.haskellPackages.nix-buildkite;
-in
-pkgs.writeScript "nix-buildkite" "${nix-buildkite}/bin/nix-buildkite"


### PR DESCRIPTION
This is broken - it doesn't forward arguments. Instead, we use jobs.nix.