### PR TITLE
Add support for Cachix writes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,22 @@ steps:
 
 That's it! Following these steps should give you a working pipeline that builds
 `nix-buildkite`.
+
+## Cachix support
+
+In your `.buildkite/pipeline.yml` file, if you set the `CACHIX_NAME`
+environment variable to the name of a Cachix binary cache, your
+Buildkite agents will write the Nix derivations they build to that
+cache.
+
+This feature requires either that you set the `CACHIX_AUTH_TOKEN`
+pipeline secret (https://buildkite.com/docs/pipelines/secrets), or
+that you configure an auth token in each Buildkite agent's home
+directory via the `cachix authtoken` command. In either case, the
+token must provide write access to the cache.
+
+Additionally, your Buildkite agent's path should include both the
+`cachix` and `tee` executables, and the agent's shell must support
+process substitution
+(https://en.wikipedia.org/wiki/Process_substitution).
+

--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -42,6 +42,8 @@ import System.Process hiding ( env )
 import Data.Text ( pack, unpack )
 import Data.Text.IO ( readFile )
 
+-- sort
+import Data.Sort ( uniqueSort )
 
 main :: IO ()
 main = do
@@ -49,7 +51,7 @@ main = do
 
   -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
   -- things that may need to be built.
-  inputDrvPaths <- Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] ""
+  inputDrvPaths <- uniqueSort <$> Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] ""
 
   -- Build an association list of a job name and the derivation that should be
   -- realised for that job.

--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -21,7 +21,7 @@ import Data.Maybe ( fromMaybe, listToMaybe )
 import Data.Traversable ( for )
 import qualified Prelude
 import Prelude hiding ( getContents, lines, readFile, words )
-import System.Environment ( getArgs )
+import System.Environment ( getArgs, lookupEnv )
 
 -- bytestring
 import qualified Data.ByteString.Lazy
@@ -49,9 +49,15 @@ main :: IO ()
 main = do
   jobsExpr <- fromMaybe "./jobs.nix" . listToMaybe <$> getArgs
 
+  cachixCmd <- do
+    cachixName <- lookupEnv "CACHIX_NAME"
+    case cachixName of
+      Nothing -> pure ""
+      Just name -> pure $ " | tee >(cachix push " <> name <> " >/dev/null 2>&1)"
+
   -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
   -- things that may need to be built.
-  inputDrvPaths <- uniqueSort <$> Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] ""
+  inputDrvPaths <- uniqueSort <$>  Prelude.lines <$> readCreateProcess (shell $ unwords ["nix-instantiate", jobsExpr, cachixCmd]) ""
 
   -- Build an association list of a job name and the derivation that should be
   -- realised for that job.
@@ -79,7 +85,7 @@ main = do
           step label drvPath =
             object
               [ "label" .= unpack label
-              , "command" .= String (pack ("nix-store -r" <> drvPath))
+              , "command" .= String (pack ("nix-store -r" <> drvPath <> cachixCmd))
               , "key" .= stepify drvPath
               , "depends_on" .= dependencies
               ]

--- a/nix-buildkite.cabal
+++ b/nix-buildkite.cabal
@@ -20,6 +20,7 @@ executable nix-buildkite
                  , unordered-containers ^>= 0.2.10.0
                  , attoparsec ^>= 0.13.2.3
                  , nix-derivation ^>= 1.1.1
+                 , sort ^>= 1.0
   default-language:    Haskell2010
   hs-source-dirs:      exe-nix-buildkite
   ghc-options: -Wcompat -Wall -fwarn-incomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wmissing-export-lists


### PR DESCRIPTION
Note that we need to be creative with `tee` and some shell process substitution in order to output the derivations both to stdout and also to the `cachix push` process. This technique is documented here: https://unix.stackexchange.com/a/371701

See the README for details on how to use this feature.

This PR depends on #11 as they touch the same code.