### PR TITLE
Add support for a per-pipeline Nix post-build-hook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ steps:
     label: ":pipeline:"
 ```
 
+## Post-build hooks
+
+The plugin accepts an optional `post-build-hook` argument, whose value
+is the name (or path) of an executable that's compatible with Nix's
+[post-build hook
+semantics](https://nixos.org/manual/nix/stable/advanced-topics/post-build-hook.html):
+
+``` yaml
+steps:
+  - command: nix-buildkite
+    label: ":nixos: :buildkite:"
+    plugins:
+      circuithub/nix-buildkite:
+        file: jobs.nix
+        post-build-hook: /etc/nix/upload-to-cache.sh
+```
+
+When specified, the plugin will run this hook after its
+`nix-instantiate` phase, and after each individual job that it
+creates. This option is useful when you want to take advantage of
+Nix's post-build hook feature (e.g., to upload the derivations created
+by the pipeline), but you don't want to enable a system-wide
+post-build hook. For example, you might only want to upload some
+pipelines' outputs to your binary cache, or you might want to upload
+different pipelines' outputs to different binary caches.
+
+Note that in order to use this feature, you'll need to add the user
+that the Buildkite agent runs as to `nix.trustedUsers`, as only
+trusted users can run post-build hooks.
+
 ## Sit Back and Enjoy!
 
 That's it! Following these steps should give you a working pipeline that builds

--- a/hooks/command
+++ b/hooks/command
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 NIX_FILE="$BUILDKITE_PLUGIN_NIX_BUILDKITE_FILE"
+if [[ -n "${BUILDKITE_PLUGIN_NIX_BUILDKITE_POST_BUILD_HOOK:-}" ]]; then
+    export POST_BUILD_HOOK="$BUILDKITE_PLUGIN_NIX_BUILDKITE_POST_BUILD_HOOK"
+fi
 
 echo "--- :nixos: Running nix-buildkite"
 nix-build -E '(import "${ builtins.fetchGit { url = https://github.com/circuithub/nix-buildkite-buildkite-plugin; ref = "main"; } }/jobs.nix").nix-buildkite' -o nix-buildkite

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,4 +6,11 @@ configuration:
   properties:
     file:
       type: string
+    post-build-hook:
+      type: string
+  required:
+    - file
+  not:
+    required:
+      - post-build-hook
   additionalProperties: false


### PR DESCRIPTION
This PR accomplishes what I was trying to do with #12, but in a more generic, more secure, and more robust way. With this change, you can optionally run any Nix `post-build-hook` you want on a per-pipeline basis (assuming the Buildkite agent is in `nix.trustedUsers`).

I've been using this in production to upload to different Cachix caches (depending on the pipeline being built), and it's working well.

This PR is based on #11 as it touches the same code.

I implemented this option as an environment variable, as otherwise it would probably require pulling in a dependency like `optparse-applicative`. Since the plugin isn't meant to be used interactively, this is probably fine, but let me know if you'd prefer it to be a command line option.