### PR TITLE
GitHub has a brownout refusing git:// so use https:// instead

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -4,7 +4,7 @@ set -euo pipefail
 NIX_FILE="$BUILDKITE_PLUGIN_NIX_BUILDKITE_FILE"
 
 echo "--- :nixos: Running nix-buildkite"
-nix-build -E '(import "${ builtins.fetchGit { url = git://github.com/circuithub/nix-buildkite-buildkite-plugin; } }/jobs.nix").nix-buildkite' -o nix-buildkite
+nix-build -E '(import "${ builtins.fetchGit { url = https://github.com/circuithub/nix-buildkite-buildkite-plugin; } }/jobs.nix").nix-buildkite' -o nix-buildkite
 PIPELINE=$( ./nix-buildkite/bin/nix-buildkite "$NIX_FILE" )
 rm nix-buildkite
 


### PR DESCRIPTION
Use `https` instead of the unsecured `git` protocol.