### PR TITLE
Hardcode ref to main

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -4,7 +4,7 @@ set -euo pipefail
 NIX_FILE="$BUILDKITE_PLUGIN_NIX_BUILDKITE_FILE"
 
 echo "--- :nixos: Running nix-buildkite"
-nix-build -E '(import "${ builtins.fetchGit { url = https://github.com/circuithub/nix-buildkite-buildkite-plugin; } }/jobs.nix").nix-buildkite' -o nix-buildkite
+nix-build -E '(import "${ builtins.fetchGit { url = https://github.com/circuithub/nix-buildkite-buildkite-plugin; ref = "refs/heads/main"; } }/jobs.nix").nix-buildkite' -o nix-buildkite
 PIPELINE=$( ./nix-buildkite/bin/nix-buildkite "$NIX_FILE" )
 rm nix-buildkite
 


### PR DESCRIPTION
I'm not sure what changed that created this issue; I think it started when I switched to Nix 2.4. I was getting this error, and the PR fixed it:

```
# nix-build -E '(import "${ builtins.fetchGit { url = https://github.com/circuithub/nix-buildkite-buildkite-plugin; } }/jobs.nix").nix-buildkite' -o nix-buildkite
fatal: couldn't find remote ref refs/heads/master
error: program 'git' failed with exit code 128
(use '--show-trace' to show detailed location information)
```