### PR TITLE
Nicer job names -- prefix with system and sort

### DIFF
--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -37,7 +37,7 @@ import System.FilePath
 import Nix.Derivation
 
 -- process
-import System.Process hiding ( env )
+import System.Process hiding ( env, system )
 
 -- text
 import Data.Text ( pack, unpack )
@@ -68,14 +68,16 @@ main = do
         return (pack (takeFileName drvPath), drvPath)
 
       Right drv ->
-        case Map.lookup "name" (env drv) of
-          Nothing ->
-            -- There was no 'name' environment variable, so we'll just use the
-            -- derivation name.
-            return (pack (takeFileName drvPath), drvPath)
-
-          Just name ->
-            return (name, drvPath)
+        let name = case Map.lookup "name" (env drv) of
+                      Nothing ->
+                      -- There was no 'name' environment variable, so we'll just use the
+                      -- derivation name.
+                        pack (takeFileName drvPath)
+                      Just n -> n
+            system = case Map.lookup "system" (env drv) of
+                       Nothing -> ""
+                       Just s -> s <> ":"
+        in return (system <> name, drvPath)
 
   g <- foldr (\(_, drv) m -> m >>= \g -> add g drv) (pure empty) drvs
 

--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -17,6 +17,7 @@ import Data.Attoparsec.Text ( parseOnly )
 
 -- base
 import Data.Char
+import Data.List ( sortOn )
 import Data.Maybe ( fromMaybe, listToMaybe )
 import Data.Traversable ( for )
 import qualified Prelude
@@ -84,17 +85,17 @@ main = do
 
   let steps = map (uncurry step) drvs
         where
-          step label drvPath =
+          step label drvPath = (label,
             object
               [ "label" .= unpack label
               , "command" .= String (pack $ unwords $ [ "nix-store" ] <> postBuildHook <> [ "-r", drvPath ])
               , "key" .= stepify drvPath
               , "depends_on" .= dependencies
-              ]
+              ])
             where
               dependencies = map stepify $ filter (`elem` map snd drvs) $ drop 1 $ reachable drvPath g
 
-  Data.ByteString.Lazy.putStr $ encode $ object [ "steps" .= steps ]
+  Data.ByteString.Lazy.putStr $ encode $ object [ "steps" .= map snd ( sortOn fst steps ) ]
 
 -- Transform nix platforms into buildkite emoji
 -- See https://github.com/buildkite/emojis


### PR DESCRIPTION
(This is somewhat of an RFC -- see end of this message. We have been using this in CI for months with no problems.)

Motivation: we have CI set up to test on multiple architectures, with many jobs per architecture. This leads to two annoyances for humans looking at the buildkite webpages. Firstly, there are multiple jobs with the same name and if only one of them fails it can be difficult to work out which architecture was the problem. Secondly they are ordered rather strangely (I think depending on some nix internals), making it difficult to eyeball progress, or find the same job on another architecture.

Solution: we add a prefix to the job names detailing the system, and sort all jobs by name. We also have a list of exceptions which we do not prefix, which we use for a `required` meta-job which just depends on everything else, and is hooked up to github's status integration (since we don't care what system this runs on).

(Potential) todos if some PRs along these lines is of interest:
- [ ] make the list of exceptions configurable https://buildkite.com/docs/plugins/using#configuring-plugins (and remove the `TODO` in the code)
- [ ] make emojis optional
- [ ] make prefixing optional
- [ ] split into 2 prs: one for prefixing, one for sorting