### PR TITLE
Allow using nix-build --dry-run

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -8,6 +8,10 @@ if [[ -n "${BUILDKITE_PLUGIN_NIX_BUILDKITE_POST_BUILD_HOOK:-}" ]]; then
     export POST_BUILD_HOOK="$BUILDKITE_PLUGIN_NIX_BUILDKITE_POST_BUILD_HOOK"
 fi
 
+if [[ -n "${BUILDKITE_PLUGIN_NIX_BUILDKITE_SKIP_ALREADY_BUILT:-}" ]]; then
+    export SKIP_ALREADY_BUILT=true
+fi
+
 echo "--- :nixos: Running nix-buildkite"
 nix-build -E "(import $DIR/../jobs.nix).nix-buildkite" -o nix-buildkite
 PIPELINE=$( ./nix-buildkite/bin/nix-buildkite "$NIX_FILE" )

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,9 +8,12 @@ configuration:
       type: string
     post-build-hook:
       type: string
+    skip-already-built:
+      type: string
   required:
     - file
   not:
     required:
       - post-build-hook
+      - skip-already-built
   additionalProperties: false


### PR DESCRIPTION
This gives us a list of only the deriviations that aren't already built. This can make a big difference if we have a lot of jobs.

Enabled through an env var