### PR TITLE
Improvements to SKIP_ALREADY_BUILT

### DIFF
--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -115,8 +115,10 @@ main = do
   useNixBuildDryRun <- do
     e <- lookupEnv "SKIP_ALREADY_BUILT"
     pure $ case e of
+      Just "true" -> True
+      Just "false" -> False
+      Just _ -> error "SKIP_ALREADY_BUILT only accepts 'true' or 'false'."
       Nothing -> False
-      Just _ -> True
 
   -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
   -- things that may need to be built.


### PR DESCRIPTION
- **Refactor nixBuildDryRun to handle exit codes**
  Before we would return [] if the child failed
  

- **Improve SKIP_ALREADY_BUILT parsing**
  Make "SKIP_ALREADY_BUILT=false" disable the flag.
  Any unknown setting will throw an error
  

- **Only create jobs for derivations in jobsExpr**
  When using SKIP_ALREADY_BUILT we have to be careful to take the
  intersection of the derivations from jobsExpr and the jobs that would be
  built to realise those derivations.
  
  Previously we weren't careful and we would create tons of jobs for
  unbuilt paths in the dependency closure of those derivations.
  
  This should fix it and only evaluate jobsExpr once (expensive).

- **Handle there not being a "these packages will be built" line**
We want to ignore all the input if there is no "these packages will be
built" line. since you might just have packages that are fetched
  