### PR TITLE
Move logic to library so tests can run without calling cabal

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,6 @@
 steps:
+  - command: nix-shell --run "cabal test"
+    label: ":test_tube: Run tests"
   - command: nix-buildkite
     label: ":nixos: :buildkite:"
     plugins:

--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -1,125 +1,20 @@
-{-# language BlockArguments #-}
-{-# language LambdaCase #-}
-{-# language NamedFieldPuns #-}
 {-# language OverloadedStrings #-}
-{-# language NumericUnderscores #-}
 
 module Main ( main ) where
 
--- algebraic-graphs
-import Algebra.Graph.AdjacencyMap ( AdjacencyMap, edge, empty, hasVertex, overlay, overlays, postSet, preSet, vertices, vertexSet )
-import qualified Algebra.Graph.AdjacencyMap.Algorithm as AMA
-
--- aeson
-import Data.Aeson ( Value(..), (.=), encode, object )
-
--- attoparsec
-import Data.Attoparsec.Text ( parseOnly )
-
--- base
-import Data.Char
-import Data.Maybe ( fromMaybe, listToMaybe, mapMaybe )
-import Data.Foldable ( toList )
-import Data.Traversable ( for )
-import Data.List (partition)
-import qualified Prelude
-import Prelude hiding ( getContents, lines, readFile, words )
-import Text.Read ( readMaybe )
-import System.Environment ( getArgs, lookupEnv )
-import System.IO (hPutStrLn, hGetContents, stderr)
-import Text.Printf (printf)
-import qualified Data.List as List
-import System.Exit (ExitCode(..))
-
--- bytestring
+import Data.Aeson ( encode, object, (.=) )
+import Data.Maybe ( fromMaybe, listToMaybe )
 import qualified Data.ByteString.Lazy.Char8 as BL
+import System.Environment ( getArgs, lookupEnv )
+import Text.Read ( readMaybe )
 
--- clock
-import System.Clock
-
--- containers
-import Data.Containers.ListUtils ( nubOrd )
-import qualified Data.Map as Map
-import qualified Data.Set as S
-
--- filepath
-import System.FilePath
-
--- nix-derivation
-import Nix.Derivation
-
--- process
-import System.Process hiding ( env )
-
--- text
-import Data.Text ( Text, pack, unpack )
-import Data.Text.IO ( readFile )
-
-
-withTime :: String -> IO a -> IO a
-withTime label k = do
-  before <- click
-  res <- k
-  after <- click
-  let delta = diffTimeSpec before after
-  hPutStrLn stderr $ printf "%s took %F seconds" label (fromIntegral (toNanoSecs delta) / (1_000_000_000 :: Double))
-  pure res
-  where
-    click = getTime Monotonic
-
-nixInstantiate :: String -> IO [String]
-nixInstantiate jobsExpr = withTime "nix-instantiate" (Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] "")
-
-nixBuildDryRun :: [String] -> IO [String]
-nixBuildDryRun jobsExpr = withTime "nix-build --dry-run" $
-  withCreateProcess ((proc "nix-build" (["--dry-run"] ++ jobsExpr)) { std_err = CreatePipe }) $ \ _stdin _stdout stderrHndl prchndl -> do
-    inputLines <- Prelude.lines <$> case stderrHndl of
-      Just hndl -> hGetContents hndl
-      Nothing -> pure []
-    -- See Note: [nix-build --dry-run output]
-    let stripLeadingWhitespace = dropWhile (==' ')
-    let theseLine line = List.isPrefixOf "these" line || List.isPrefixOf "this" line
-    let buildLine line = theseLine line && List.isSubsequenceOf "built" line
-    let fetchLine line = theseLine line && List.isSubsequenceOf "fetched" line
-
-    -- dump the output to stderr
-    mapM_ (hPutStrLn stderr) inputLines
-
-    let res = map stripLeadingWhitespace . takeWhile (not . fetchLine) . drop 1 $ dropWhile (not . buildLine) inputLines
-    exitCode <- waitForProcess prchndl
-    case exitCode of
-      ExitSuccess -> pure res
-      ExitFailure err -> error $ "nix-build --dry run failed with exit code: " ++ show err
-
--- Note: [nix-build --dry-run output]
--- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
--- The output of `nix-build --dry-run` looks like this (on stderr! not stdout):
--- > trace: ...
--- > these 201 derivations will be built:
--- >   /nix/store/foo.drv
--- >   /nix/store/bar.drv
--- >   /nix/store/baz.drv
--- >   ...
--- > these 499 paths will be fetched (1607.21 MiB download, 6356.04 MiB unpacked):
--- >   /nix/store/foo1
--- >   ...
--- What we want to do is drop everything until the first line starting with "these", strip the leading whitespace,
--- and grab everything until we get to the second "these"
---
--- NB: you might not have any derivations to be built.
---
--- NB: if only one deriviation needs to be built, then you need to look out for "this" rather than "these"
-
+import NixBuildkite ( Config(..), defaultConfig, generatePipeline )
 
 main :: IO ()
 main = do
   jobsExpr <- fromMaybe "./jobs.nix" . listToMaybe <$> getArgs
 
-  postBuildHook <- do
-    cmd <- lookupEnv "POST_BUILD_HOOK"
-    case cmd of
-      Nothing -> return []
-      Just path -> return $ [ "--post-build-hook", path ]
+  postBuildHook <- lookupEnv "POST_BUILD_HOOK"
 
   skipAlreadyBuilt <- do
     e <- lookupEnv "SKIP_ALREADY_BUILT"
@@ -129,146 +24,19 @@ main = do
       Just _ -> error "SKIP_ALREADY_BUILT only accepts 'true' or 'false'."
       Nothing -> False
 
-  -- Batch size for pipeline uploads (Buildkite has a 500 job limit per upload)
   batchSize <- do
     e <- lookupEnv "BATCH_SIZE"
     pure $ case e of
-      Nothing -> 450
+      Nothing -> configBatchSize defaultConfig
       Just s -> fromMaybe (error "BATCH_SIZE must be a positive integer") (readMaybe s)
 
-  -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
-  -- things that may need to be built.
-  inputDrvPaths <- nubOrd <$> nixInstantiate jobsExpr
+  let config = Config
+        { configPostBuildHook = postBuildHook
+        , configSkipAlreadyBuilt = skipAlreadyBuilt
+        , configBatchSize = batchSize
+        }
 
-  -- Get the list of derivations that will be built, which may include drvs not in inputDrvPaths
-  pathsToBuild <- if skipAlreadyBuilt then nixBuildDryRun (inputDrvPaths) else pure inputDrvPaths
+  batches <- generatePipeline config jobsExpr
 
-  -- Filter our inputDrvs down to just those that will be built (if the skip already built flag is set)
-  let inputDrvPathsToBuild = S.toList $ S.fromList inputDrvPaths `S.intersection` S.fromList pathsToBuild
-
-  -- Build an association list of a job name and the derivation that should be
-  -- realised for that job.
-  drvs <- for inputDrvPathsToBuild \drvPath -> do
-    fmap (parseOnly parseDerivation) (readFile drvPath) >>= \case
-      Left _ ->
-        -- We couldn't parse the derivation to get a name, so we'll just use the
-        -- derivation name.
-        return (pack (takeFileName drvPath), drvPath)
-
-      Right drv ->
-        case Map.lookup "name" (env drv) of
-          Nothing ->
-            -- There was no 'name' environment variable, so we'll just use the
-            -- derivation name.
-            return (pack (takeFileName drvPath), drvPath)
-
-          Just name ->
-            return (name, drvPath)
-
-  g <- foldr (\(_, drv) m -> m >>= \g -> add g drv) (pure empty) drvs
-
-  let jobSet = S.fromList $ map snd drvs
-
-  -- See Note [Pipeline batching]
-  --
-  -- Build the job dependency graph. Conceptually, we want:
-  --   transitive closure of g → restrict to jobs → transitive reduction
-  -- This gives us direct job-to-job dependencies, collapsing through non-job intermediates
-  -- (e.g., jobB -> intermediate -> jobA becomes jobB -> jobA) but without redundant edges
-  -- (e.g., if jobC -> jobB -> jobA, we don't want jobC -> jobA since Buildkite handles that).
-  --
-  -- Since algebraic-graphs doesn't provide transitive reduction, we compute this directly
-  -- by recursing through non-job nodes but stopping at jobs. We use a Map for memoization.
-  let depsOf v = fromMaybe S.empty $ Map.lookup v depsMap
-        where
-          depsMap = Map.fromList
-            [(v', us) |
-              v' <- S.toList (vertexSet g),
-              let nexts = S.toList $ postSet v' g,
-              let (ins, outs) = partition (`S.member` jobSet) nexts,
-              let us = S.unions $ S.fromList ins : map depsOf outs
-            ]
-
-  let jobGraph :: AdjacencyMap FilePath
-      jobGraph = overlay (vertices $ S.toList jobSet) $
-        overlays
-          [ overlays [edge dep job | dep <- S.toList (depsOf job)]  -- edge from dependency to dependent
-          | job <- S.toList jobSet
-          ]
-
-  -- Topological sort: dependencies come before dependents.
-  -- For edge (A -> B), topSort returns A before B. Our edges go from dependency to dependent,
-  -- so dependencies come first in the result.
-  let sortedDrvPaths = case AMA.topSort jobGraph of
-        Left depCycle -> error $ "Dependency cycle detected: " ++ unwords (toList depCycle)
-        Right sorted -> sorted
-
-  -- Create a map from drvPath to label for quick lookup
-  let drvLabels = Map.fromList [(drvPath, label) | (label, drvPath) <- drvs]
-
-  -- Map sorted paths back to (label, path) pairs
-  let sortedDrvs = mapMaybe (\drvPath -> fmap (\label -> (label, drvPath)) (Map.lookup drvPath drvLabels)) sortedDrvPaths
-
-  let step :: Text -> FilePath -> Value
-      step label drvPath =
-        object
-          [ "label" .= unpack label
-          , "command" .= String (pack $ unwords $ [ "nix-store" ] <> postBuildHook <> [ "-r", drvPath ])
-          , "key" .= stepify drvPath
-          , "depends_on" .= dependencies
-          ]
-        where
-          dependencies = map stepify $ S.toList $ preSet drvPath jobGraph
-
-  let steps = map (uncurry step) sortedDrvs
-
-  -- Split steps into batches and output one JSON object per line
-  let batches = chunksOf batchSize steps
+  -- Output one JSON object per line
   mapM_ (\batch -> BL.putStrLn $ encode $ object [ "steps" .= batch ]) batches
-
--- | Split a list into chunks of at most n elements.
-chunksOf :: Int -> [a] -> [[a]]
-chunksOf _ [] = []
-chunksOf n xs = take n xs : chunksOf n (drop n xs)
-
--- | Convert a derivation path to a valid Buildkite step key.
--- Buildkite step keys are limited to 100 characters and may only contain
--- alphanumeric characters, '/', and '-'.
-stepify :: String -> String
-stepify = take 99 . map replace . takeBaseName
-  where
-    replace x | isAlphaNum x = x
-    replace '/' = '/'
-    replace '-' = '-'
-    replace _ = '_'
-
-add :: AdjacencyMap FilePath -> FilePath -> IO (AdjacencyMap FilePath)
-add g drvPath =
-  if hasVertex drvPath g then
-    return g
-
-  else
-    fmap (parseOnly parseDerivation) (readFile drvPath) >>= \case
-      Left _ ->
-        return g
-
-      Right Derivation{ inputDrvs } -> do
-        deps <- foldr (\dep m -> m >>= \g' -> add g' dep) (pure g) (Map.keys inputDrvs)
-
-        let g' = overlays (edge drvPath <$> Map.keys inputDrvs)
-
-        return $ overlay deps g'
-
-{- Note [Pipeline batching]
-
-Buildkite has a limit of 500 jobs per pipeline upload. To support larger
-pipelines, we split the steps into batches and output one JSON object per
-line. The calling shell script uploads each batch sequentially.
-
-We topologically sort the steps so that dependencies appear before the steps
-that depend on them. This ensures that when uploading batches sequentially,
-a step's dependencies are always uploaded in an earlier (or the same) batch.
-Buildkite resolves `depends_on` references across separate uploads, so this
-ordering is sufficient for correctness.
--}
-

--- a/nix-buildkite.cabal
+++ b/nix-buildkite.cabal
@@ -7,23 +7,32 @@ maintainer:          oliver.charles@circuithub.com
 build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md
 
+library
+  exposed-modules:     NixBuildkite
+  hs-source-dirs:      src
+  build-depends:       aeson ^>= 1.4.6.0 || ^>= 1.5.4.0
+                     , algebraic-graphs ^>= 0.5
+                     , base ^>= 4.12 || ^>= 4.13 || ^>= 4.14
+                     , bytestring ^>= 0.10.8.2
+                     , containers ^>= 0.6.0.1
+                     , filepath ^>= 1.4.2.1
+                     , process ^>= 1.6.5.0
+                     , text ^>= 1.2.3.1
+                     , attoparsec ^>= 0.13.2.3
+                     , nix-derivation ^>= 1.1.1
+                     , clock ^>= 0.8
+  default-language:    Haskell2010
+  ghc-options:         -Wcompat -Wall
+
 executable nix-buildkite
   main-is:             Main.hs
-  build-depends:   aeson ^>= 1.4.6.0 || ^>= 1.5.4.0
-                 , algebraic-graphs ^>= 0.5
-                 , base ^>= 4.12 || ^>= 4.13 || ^>= 4.14
-                 , bytestring ^>= 0.10.8.2
-                 , containers ^>= 0.6.0.1
-                 , filepath ^>= 1.4.2.1
-                 , process ^>= 1.6.5.0
-                 , text ^>= 1.2.3.1
-                 , unordered-containers ^>= 0.2.10.0
-                 , attoparsec ^>= 0.13.2.3
-                 , nix-derivation ^>= 1.1.1
-                 , clock ^>= 0.8
+  build-depends:       base ^>= 4.12 || ^>= 4.13 || ^>= 4.14
+                     , aeson ^>= 1.4.6.0 || ^>= 1.5.4.0
+                     , bytestring ^>= 0.10.8.2
+                     , nix-buildkite
   default-language:    Haskell2010
   hs-source-dirs:      exe-nix-buildkite
-  ghc-options: -Wcompat -Wall -fwarn-incomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Wredundant-constraints -Wmissing-export-lists
+  ghc-options:         -Wcompat -Wall
 
 test-suite nix-buildkite-tests
   type:                exitcode-stdio-1.0
@@ -31,8 +40,7 @@ test-suite nix-buildkite-tests
   hs-source-dirs:      test
   build-depends:       base ^>= 4.12 || ^>= 4.13 || ^>= 4.14
                      , aeson ^>= 1.4.6.0 || ^>= 1.5.4.0
-                     , bytestring ^>= 0.10.8.2
-                     , process ^>= 1.6.5.0
+                     , nix-buildkite
                      , tasty
                      , tasty-hunit
                      , text ^>= 1.2.3.1

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -9,13 +9,15 @@ let
   inherit (haskell.lib) appendConfigureFlag dontCheck packagesFromDirectory;
 
   inherit (super.lib) composeExtensions cleanSource;
-  
+
   WError =
     drv: appendConfigureFlag drv "--ghc-option=-Werror";
 
   configurations =
     _self: _super: {
-      # Tests require nix-instantiate which isn't available in the nix sandbox
+      # Tests require nix-instantiate to run, which needs access to /nix/var
+      # and the nix daemon. These aren't available inside the nix sandbox,
+      # so we disable tests here and run them separately in CI.
       nix-buildkite = dontCheck (WError (callCabal2nix "nix-buildkite" (cleanSource ../../.) {}));
     };
 

--- a/src/NixBuildkite.hs
+++ b/src/NixBuildkite.hs
@@ -1,0 +1,288 @@
+{-# language BlockArguments #-}
+{-# language LambdaCase #-}
+{-# language NamedFieldPuns #-}
+{-# language OverloadedStrings #-}
+{-# language NumericUnderscores #-}
+
+module NixBuildkite
+  ( -- * Configuration
+    Config(..)
+  , defaultConfig
+    -- * Pipeline generation
+  , generatePipeline
+    -- * Utilities (exported for testing)
+  , chunksOf
+  , stepify
+  ) where
+
+-- algebraic-graphs
+import Algebra.Graph.AdjacencyMap ( AdjacencyMap, edge, empty, hasVertex, overlay, overlays, postSet, preSet, vertices, vertexSet )
+import qualified Algebra.Graph.AdjacencyMap.Algorithm as AMA
+
+-- aeson
+import Data.Aeson ( Value(..), (.=), object )
+
+-- attoparsec
+import Data.Attoparsec.Text ( parseOnly )
+
+-- base
+import Data.Char ( isAlphaNum )
+import Data.Maybe ( fromMaybe, mapMaybe )
+import Data.Foldable ( toList )
+import Data.Traversable ( for )
+import Data.List ( partition )
+import qualified Prelude
+import Prelude hiding ( readFile )
+import System.IO ( hPutStrLn, hGetContents, stderr )
+import Text.Printf ( printf )
+import qualified Data.List as List
+import System.Exit ( ExitCode(..) )
+
+-- clock
+import System.Clock
+
+-- containers
+import Data.Containers.ListUtils ( nubOrd )
+import qualified Data.Map as Map
+import qualified Data.Set as S
+
+-- filepath
+import System.FilePath ( takeFileName, takeBaseName )
+
+-- nix-derivation
+import Nix.Derivation ( Derivation(..), parseDerivation )
+
+-- process
+import System.Process hiding (env)
+
+-- text
+import Data.Text ( Text, pack, unpack )
+import Data.Text.IO ( readFile )
+
+
+-- | Configuration for pipeline generation.
+data Config = Config
+  { configPostBuildHook :: Maybe FilePath
+    -- ^ Optional path to a post-build hook script.
+  , configSkipAlreadyBuilt :: Bool
+    -- ^ If True, skip derivations that are already built.
+  , configBatchSize :: Int
+    -- ^ Maximum number of steps per batch (Buildkite limit is 500).
+  } deriving (Show, Eq)
+
+-- | Default configuration with sensible defaults.
+defaultConfig :: Config
+defaultConfig = Config
+  { configPostBuildHook = Nothing
+  , configSkipAlreadyBuilt = False
+  , configBatchSize = 450
+  }
+
+-- | Generate pipeline batches from a jobs.nix file.
+-- Returns a list of batches, where each batch is a list of Buildkite step values.
+generatePipeline :: Config -> FilePath -> IO [[Value]]
+generatePipeline config jobsExpr = do
+  -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
+  -- things that may need to be built.
+  inputDrvPaths <- nubOrd <$> nixInstantiate jobsExpr
+
+  -- Get the list of derivations that will be built, which may include drvs not in inputDrvPaths
+  pathsToBuild <- if configSkipAlreadyBuilt config
+    then nixBuildDryRun inputDrvPaths
+    else pure inputDrvPaths
+
+  -- Filter our inputDrvs down to just those that will be built (if the skip already built flag is set)
+  let inputDrvPathsToBuild = S.toList $ S.fromList inputDrvPaths `S.intersection` S.fromList pathsToBuild
+
+  generatePipelineFromDrvPaths config inputDrvPathsToBuild
+
+-- | Generate pipeline batches from a list of derivation paths.
+-- This is the core logic, useful for testing without needing nix-instantiate.
+generatePipelineFromDrvPaths :: Config -> [FilePath] -> IO [[Value]]
+generatePipelineFromDrvPaths config inputDrvPathsToBuild = do
+  let postBuildHook = case configPostBuildHook config of
+        Nothing -> []
+        Just path -> ["--post-build-hook", path]
+
+  -- Build an association list of a job name and the derivation that should be
+  -- realised for that job.
+  drvs <- for inputDrvPathsToBuild \drvPath -> do
+    fmap (parseOnly parseDerivation) (readFile drvPath) >>= \case
+      Left _ ->
+        -- We couldn't parse the derivation to get a name, so we'll just use the
+        -- derivation name.
+        return (pack (takeFileName drvPath), drvPath)
+
+      Right drv ->
+        case Map.lookup "name" (env drv) of
+          Nothing ->
+            -- There was no 'name' environment variable, so we'll just use the
+            -- derivation name.
+            return (pack (takeFileName drvPath), drvPath)
+
+          Just name ->
+            return (name, drvPath)
+
+  g <- foldr (\(_, drv) m -> m >>= \g' -> add g' drv) (pure empty) drvs
+
+  let jobSet = S.fromList $ map snd drvs
+
+  -- See Note [Pipeline batching]
+  --
+  -- Build the job dependency graph. Conceptually, we want:
+  --   transitive closure of g → restrict to jobs → transitive reduction
+  -- This gives us direct job-to-job dependencies, collapsing through non-job intermediates
+  -- (e.g., jobB -> intermediate -> jobA becomes jobB -> jobA) but without redundant edges
+  -- (e.g., if jobC -> jobB -> jobA, we don't want jobC -> jobA since Buildkite handles that).
+  --
+  -- Since algebraic-graphs doesn't provide transitive reduction, we compute this directly
+  -- by recursing through non-job nodes but stopping at jobs. We use a Map for memoization.
+  let depsOf v = fromMaybe S.empty $ Map.lookup v depsMap
+        where
+          depsMap = Map.fromList
+            [(v', us) |
+              v' <- S.toList (vertexSet g),
+              let nexts = S.toList $ postSet v' g,
+              let (ins, outs) = partition (`S.member` jobSet) nexts,
+              let us = S.unions $ S.fromList ins : map depsOf outs
+            ]
+
+  let jobGraph :: AdjacencyMap FilePath
+      jobGraph = overlay (vertices $ S.toList jobSet) $
+        overlays
+          [ overlays [edge dep job | dep <- S.toList (depsOf job)]  -- edge from dependency to dependent
+          | job <- S.toList jobSet
+          ]
+
+  -- Topological sort: dependencies come before dependents.
+  -- For edge (A -> B), topSort returns A before B. Our edges go from dependency to dependent,
+  -- so dependencies come first in the result.
+  let sortedDrvPaths = case AMA.topSort jobGraph of
+        Left depCycle -> error $ "Dependency cycle detected: " ++ unwords (toList depCycle)
+        Right sorted -> sorted
+
+  -- Create a map from drvPath to label for quick lookup
+  let drvLabels = Map.fromList [(drvPath, label) | (label, drvPath) <- drvs]
+
+  -- Map sorted paths back to (label, path) pairs
+  let sortedDrvs = mapMaybe (\drvPath -> fmap (\label -> (label, drvPath)) (Map.lookup drvPath drvLabels)) sortedDrvPaths
+
+  let step :: Text -> FilePath -> Value
+      step label drvPath =
+        object
+          [ "label" .= unpack label
+          , "command" .= String (pack $ unwords $ [ "nix-store" ] <> postBuildHook <> [ "-r", drvPath ])
+          , "key" .= stepify drvPath
+          , "depends_on" .= dependencies
+          ]
+        where
+          dependencies = map stepify $ S.toList $ preSet drvPath jobGraph
+
+  let steps = map (uncurry step) sortedDrvs
+
+  -- Split steps into batches
+  return $ chunksOf (configBatchSize config) steps
+
+
+-- | Split a list into chunks of at most n elements.
+chunksOf :: Int -> [a] -> [[a]]
+chunksOf _ [] = []
+chunksOf n xs = take n xs : chunksOf n (drop n xs)
+
+-- | Convert a derivation path to a valid Buildkite step key.
+-- Buildkite step keys are limited to 100 characters and may only contain
+-- alphanumeric characters, '/', and '-'.
+stepify :: String -> String
+stepify = take 99 . map replace . takeBaseName
+  where
+    replace x | isAlphaNum x = x
+    replace '/' = '/'
+    replace '-' = '-'
+    replace _ = '_'
+
+
+-- Internal helpers
+
+withTime :: String -> IO a -> IO a
+withTime label k = do
+  before <- click
+  res <- k
+  after <- click
+  let delta = diffTimeSpec before after
+  hPutStrLn stderr $ printf "%s took %F seconds" label (fromIntegral (toNanoSecs delta) / (1_000_000_000 :: Double))
+  pure res
+  where
+    click = getTime Monotonic
+
+nixInstantiate :: String -> IO [String]
+nixInstantiate jobsExpr = withTime "nix-instantiate" (Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] "")
+
+nixBuildDryRun :: [String] -> IO [String]
+nixBuildDryRun jobsExpr = withTime "nix-build --dry-run" $
+  withCreateProcess ((proc "nix-build" (["--dry-run"] ++ jobsExpr)) { std_err = CreatePipe }) $ \ _stdin _stdout stderrHndl prchndl -> do
+    inputLines <- Prelude.lines <$> case stderrHndl of
+      Just hndl -> hGetContents hndl
+      Nothing -> pure []
+    -- See Note: [nix-build --dry-run output]
+    let stripLeadingWhitespace = dropWhile (==' ')
+    let theseLine line = List.isPrefixOf "these" line || List.isPrefixOf "this" line
+    let buildLine line = theseLine line && List.isSubsequenceOf "built" line
+    let fetchLine line = theseLine line && List.isSubsequenceOf "fetched" line
+
+    -- dump the output to stderr
+    mapM_ (hPutStrLn stderr) inputLines
+
+    let res = map stripLeadingWhitespace . takeWhile (not . fetchLine) . drop 1 $ dropWhile (not . buildLine) inputLines
+    exitCode <- waitForProcess prchndl
+    case exitCode of
+      ExitSuccess -> pure res
+      ExitFailure err -> error $ "nix-build --dry run failed with exit code: " ++ show err
+
+-- Note: [nix-build --dry-run output]
+-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- The output of `nix-build --dry-run` looks like this (on stderr! not stdout):
+-- > trace: ...
+-- > these 201 derivations will be built:
+-- >   /nix/store/foo.drv
+-- >   /nix/store/bar.drv
+-- >   /nix/store/baz.drv
+-- >   ...
+-- > these 499 paths will be fetched (1607.21 MiB download, 6356.04 MiB unpacked):
+-- >   /nix/store/foo1
+-- >   ...
+-- What we want to do is drop everything until the first line starting with "these", strip the leading whitespace,
+-- and grab everything until we get to the second "these"
+--
+-- NB: you might not have any derivations to be built.
+--
+-- NB: if only one deriviation needs to be built, then you need to look out for "this" rather than "these"
+
+add :: AdjacencyMap FilePath -> FilePath -> IO (AdjacencyMap FilePath)
+add g drvPath =
+  if hasVertex drvPath g then
+    return g
+
+  else
+    fmap (parseOnly parseDerivation) (readFile drvPath) >>= \case
+      Left _ ->
+        return g
+
+      Right Derivation{ inputDrvs } -> do
+        deps <- foldr (\dep m -> m >>= \g' -> add g' dep) (pure g) (Map.keys inputDrvs)
+
+        let g' = overlays (edge drvPath <$> Map.keys inputDrvs)
+
+        return $ overlay deps g'
+
+{- Note [Pipeline batching]
+
+Buildkite has a limit of 500 jobs per pipeline upload. To support larger
+pipelines, we split the steps into batches and output one JSON object per
+line. The calling shell script uploads each batch sequentially.
+
+We topologically sort the steps so that dependencies appear before the steps
+that depend on them. This ensures that when uploading batches sequentially,
+a step's dependencies are always uploaded in an earlier (or the same) batch.
+Buildkite resolves `depends_on` references across separate uploads, so this
+ordering is sufficient for correctness.
+-}

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,16 +2,15 @@
 
 module Main (main) where
 
-import Data.Aeson (Value(..), decode, (.:))
-import Data.Aeson.Types (parseMaybe)
-import qualified Data.ByteString.Lazy.Char8 as BL
+import Data.Aeson (Value(..))
+import Data.Aeson.Types (parseMaybe, (.:))
 import qualified Data.Text as T
 import Data.Maybe (mapMaybe)
 import qualified Data.Vector as V
-import System.Environment (setEnv, lookupEnv, unsetEnv)
-import System.Process (readProcess)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, assertEqual, assertBool, (@?=))
+
+import NixBuildkite (Config(..), defaultConfig, generatePipeline)
 
 main :: IO ()
 main = defaultMain tests
@@ -40,37 +39,17 @@ tests = testGroup "nix-buildkite"
       ]
   ]
 
--- | Run nix-buildkite with the given jobs file and batch size
-runNixBuildkite :: Maybe Int -> FilePath -> IO [Value]
-runNixBuildkite batchSize jobsFile = do
-  -- Save and set BATCH_SIZE
-  oldBatchSize <- lookupEnv "BATCH_SIZE"
-  case batchSize of
-    Just n -> setEnv "BATCH_SIZE" (show n)
-    Nothing -> unsetEnv "BATCH_SIZE"
-
-  -- Run the executable
-  output <- readProcess "cabal" ["run", "-v0", "nix-buildkite", "--", jobsFile] ""
-
-  -- Restore BATCH_SIZE
-  case oldBatchSize of
-    Just v -> setEnv "BATCH_SIZE" v
-    Nothing -> unsetEnv "BATCH_SIZE"
-
-  -- Parse each line as JSON
-  let batches = mapMaybe (decode . BL.pack) (lines output)
-  return batches
-
--- | Extract steps from a batch
-getSteps :: Value -> [Value]
-getSteps (Object obj) = case parseMaybe (.: "steps") obj of
-  Just (Array arr) -> V.toList arr
-  _ -> []
-getSteps _ = []
+-- | Run the pipeline generator with the given batch size
+runWithBatchSize :: Maybe Int -> FilePath -> IO [[Value]]
+runWithBatchSize batchSize jobsFile = do
+  let config = defaultConfig
+        { configBatchSize = maybe (configBatchSize defaultConfig) id batchSize
+        }
+  generatePipeline config jobsFile
 
 -- | Get all steps from all batches
-getAllSteps :: [Value] -> [Value]
-getAllSteps = concatMap getSteps
+getAllSteps :: [[Value]] -> [Value]
+getAllSteps = concat
 
 -- | Get a field from a step
 getField :: T.Text -> Value -> Maybe Value
@@ -105,41 +84,40 @@ transitiveDepsFile = "test/fixtures/transitive-deps.nix"
 
 testIndependentBatchCount :: IO ()
 testIndependentBatchCount = do
-  batches <- runNixBuildkite (Just 2) independentJobsFile
+  batches <- runWithBatchSize (Just 2) independentJobsFile
   assertEqual "should produce 3 batches" 3 (length batches)
 
 testIndependentTotalSteps :: IO ()
 testIndependentTotalSteps = do
-  batches <- runNixBuildkite (Just 2) independentJobsFile
+  batches <- runWithBatchSize (Just 2) independentJobsFile
   let steps = getAllSteps batches
   assertEqual "should produce 5 steps" 5 (length steps)
 
 testDefaultBatchSize :: IO ()
 testDefaultBatchSize = do
-  batches <- runNixBuildkite Nothing independentJobsFile
+  batches <- runWithBatchSize Nothing independentJobsFile
   assertEqual "should produce 1 batch with default size" 1 (length batches)
 
 -- Tests for dependent jobs
 
 testDependencyOrder :: IO ()
 testDependencyOrder = do
-  batches <- runNixBuildkite (Just 2) dependentJobsFile
-  let output = unlines $ map (BL.unpack . BL.pack . show) batches
-      jobALine = findFirstLineWith "jobA" output :: Int
-      jobBLine = findFirstLineWith "jobB" output :: Int
-  assertBool "jobA should appear before jobB" (jobALine <= jobBLine)
+  batches <- runWithBatchSize (Just 2) dependentJobsFile
+  let steps = getAllSteps batches
+      stepLabels = mapMaybe getLabel steps
+      jobAIndex = findIndex "jobA" stepLabels
+      jobBIndex = findIndex "jobB" stepLabels
+  assertBool "jobA should appear before jobB" (jobAIndex <= jobBIndex)
   where
-    findFirstLineWith :: String -> String -> Int
-    findFirstLineWith needle text =
-      case filter (needle `isInfixOf`) (zip [1..] (lines text)) of
+    findIndex :: T.Text -> [T.Text] -> Int
+    findIndex needle xs =
+      case filter (\(_, x) -> needle `T.isInfixOf` x) (zip [0..] xs) of
         ((n, _):_) -> n
         [] -> maxBound
-    isInfixOf :: String -> (Int, String) -> Bool
-    isInfixOf needle (_, line) = T.pack needle `T.isInfixOf` T.pack line
 
 testJobBDependsOnJobA :: IO ()
 testJobBDependsOnJobA = do
-  batches <- runNixBuildkite (Just 2) dependentJobsFile
+  batches <- runWithBatchSize (Just 2) dependentJobsFile
   let steps = getAllSteps batches
       jobBSteps = filter (\s -> getLabel s == Just "jobB") steps
   case jobBSteps of
@@ -149,7 +127,7 @@ testJobBDependsOnJobA = do
 
 testJobCDependsOnJobB :: IO ()
 testJobCDependsOnJobB = do
-  batches <- runNixBuildkite (Just 2) dependentJobsFile
+  batches <- runWithBatchSize (Just 2) dependentJobsFile
   let steps = getAllSteps batches
       jobCSteps = filter (\s -> getLabel s == Just "jobC") steps
   case jobCSteps of
@@ -161,7 +139,7 @@ testJobCDependsOnJobB = do
 
 testTransitiveDep :: IO ()
 testTransitiveDep = do
-  batches <- runNixBuildkite Nothing transitiveDepsFile
+  batches <- runWithBatchSize Nothing transitiveDepsFile
   let steps = getAllSteps batches
       jobBSteps = filter (\s -> getLabel s == Just "jobB") steps
   case jobBSteps of
@@ -173,7 +151,7 @@ testTransitiveDep = do
 
 testRequiredFields :: IO ()
 testRequiredFields = do
-  batches <- runNixBuildkite Nothing independentJobsFile
+  batches <- runWithBatchSize Nothing independentJobsFile
   let steps = getAllSteps batches
       hasAllFields step =
         all (\f -> getField f step /= Nothing) ["label", "command", "key", "depends_on"]
@@ -184,15 +162,15 @@ testRequiredFields = do
 
 testBatchSizeLimit :: IO ()
 testBatchSizeLimit = do
-  batches <- runNixBuildkite (Just 2) independentJobsFile
-  let batchSizes = map (length . getSteps) batches
+  batches <- runWithBatchSize (Just 2) independentJobsFile
+  let batchSizes = map length batches
       maxSize = maximum batchSizes
   assertBool "no batch should exceed BATCH_SIZE" (maxSize <= 2)
 
 testBatchDistribution :: IO ()
 testBatchDistribution = do
-  batches <- runNixBuildkite (Just 2) independentJobsFile
-  let batchSizes = reverse $ sort $ map (length . getSteps) batches
+  batches <- runWithBatchSize (Just 2) independentJobsFile
+  let batchSizes = reverse $ sort $ map length batches
   batchSizes @?= [2, 2, 1]
   where
     sort = foldr insert []


### PR DESCRIPTION
Annoyingly we still can't build them in the derivation, since
`nix-instantiate` needs to access the nix store, but it's now at least
cleaner to run them in CI.
