### PR TITLE
Add support for creating GC roots

### DIFF
--- a/exe-nix-buildkite/Main.hs
+++ b/exe-nix-buildkite/Main.hs
@@ -29,6 +29,8 @@ main = do
     pure $ case e of
       Nothing -> configBatchSize defaultConfig
       Just s -> fromMaybe (error "BATCH_SIZE must be a positive integer") (readMaybe s)
+      
+  gcRoot <- lookupEnv "GC_ROOT"
 
   -- If set, collapse to a single "build everything" job once the pipeline would
   -- exceed this many steps. Unset means no limit.
@@ -43,6 +45,7 @@ main = do
         , configSkipAlreadyBuilt = skipAlreadyBuilt
         , configBatchSize = batchSize
         , configMaxSteps = maxSteps
+        , configGcRoot = gcRoot
         }
 
   batches <- generatePipeline config jobsExpr

--- a/hooks/command
+++ b/hooks/command
@@ -20,6 +20,10 @@ if [[ -n "${BUILDKITE_PLUGIN_NIX_BUILDKITE_MAX_STEPS:-}" ]]; then
     export MAX_STEPS="$BUILDKITE_PLUGIN_NIX_BUILDKITE_MAX_STEPS"
 fi
 
+if [[ -n "${BUILDKITE_PLUGIN_NIX_BUILDKITE_GC_ROOT:-}" ]]; then
+    export GC_ROOT="$BUILDKITE_PLUGIN_NIX_BUILDKITE_GC_ROOT"
+fi
+
 echo "--- :nixos: Running nix-buildkite"
 nix-build -E "(import $DIR/../jobs.nix).nix-buildkite" -o nix-buildkite
 PIPELINE=$( ./nix-buildkite/bin/nix-buildkite "$NIX_FILE" )

--- a/nix-buildkite.cabal
+++ b/nix-buildkite.cabal
@@ -16,6 +16,7 @@ library
                      , bytestring ^>= 0.10.8.2
                      , containers ^>= 0.6.0.1
                      , filepath ^>= 1.4.2.1
+                     , directory ^>= 1.3.3
                      , process ^>= 1.6.5.0
                      , text ^>= 1.2.3.1
                      , attoparsec ^>= 0.13.2.3

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,6 +14,8 @@ configuration:
       type: integer
     max-steps:
       type: integer
+    gc-root:
+      type: string
   required:
     - file
   not:
@@ -22,4 +24,5 @@ configuration:
       - skip-already-built
       - batch-size
       - max-steps
+      - gc-root
   additionalProperties: false

--- a/src/NixBuildkite.hs
+++ b/src/NixBuildkite.hs
@@ -48,6 +48,9 @@ import Data.Containers.ListUtils ( nubOrd )
 import qualified Data.Map as Map
 import qualified Data.Set as S
 
+-- directory
+import System.Directory (pathIsSymbolicLink, getSymbolicLinkTarget)
+
 -- filepath
 import System.FilePath ( takeFileName, takeBaseName )
 
@@ -78,6 +81,8 @@ data Config = Config
     -- ^ If set, and the pipeline would produce more than this many steps,
     -- collapse the whole pipeline into a single job that builds everything
     -- (see 'generatePipelineFromDrvPaths'). 'Nothing' means no limit.
+  , configGcRoot :: Maybe FilePath
+    -- ^ When specified create a gc root for all instantiated derivations in a subdirectory of this path.
   } deriving (Show, Eq)
 
 -- | Default configuration with sensible defaults.
@@ -87,6 +92,7 @@ defaultConfig = Config
   , configSkipAlreadyBuilt = False
   , configBatchSize = 450
   , configMaxSteps = Nothing
+  , configGcRoot = Nothing
   }
 
 -- | Sometimes nix will return stuff that looks like @/nix/store/asdfasdf-foo.drv!doc@.
@@ -102,14 +108,19 @@ generatePipeline :: Config -> FilePath -> IO [[Value]]
 generatePipeline config jobsExpr = do
   -- Run nix-instantiate on the jobs expression to instantiate .drvs for all
   -- things that may need to be built.
-  inputDrvPaths <- nubOrd . map removeBang <$> nixInstantiate jobsExpr
+  inputDrvPathsWithLinks <- nubOrd . map removeBang <$> nixInstantiate config jobsExpr
+
+  -- When we create gc-roots, then nix-instantiate will return the new gc-root paths,
+  -- rather than the store paths, so let's resolve symlinks to get the store paths.
+  -- This will be a no-op otherwise.
+  inputDrvPaths <- traverse (\p -> pathIsSymbolicLink p >>= \b -> if b then getSymbolicLinkTarget p else pure p) inputDrvPathsWithLinks
 
   -- Get the list of derivations that will be built, which may include drvs not in inputDrvPaths
   pathsToBuild <- if configSkipAlreadyBuilt config
     then nixBuildDryRun inputDrvPaths
     else pure inputDrvPaths
 
-  -- Filter our inputDrvs down to just those that will be built (if the skip already built flag is set)
+  -- Filter our inputDrvs down to just those that will be built (if the "skip already built" flag is set)
   let inputDrvPathsToBuild = S.toList $ S.fromList inputDrvPaths `S.intersection` S.fromList pathsToBuild
 
   generatePipelineFromDrvPaths config inputDrvPathsToBuild
@@ -347,8 +358,12 @@ withTime label k = do
   where
     click = getTime Monotonic
 
-nixInstantiate :: String -> IO [String]
-nixInstantiate jobsExpr = withTime "nix-instantiate" (Prelude.lines <$> readProcess "nix-instantiate" [ jobsExpr ] "")
+nixInstantiate :: Config -> String -> IO [String]
+nixInstantiate config jobsExpr = do
+  let gcRootArg = case configGcRoot config of
+        Nothing -> []
+        Just path -> ["--add-root", path]
+  withTime "nix-instantiate" (Prelude.lines <$> readProcess "nix-instantiate" (gcRootArg ++ [ jobsExpr ]) "")
 
 nixBuildDryRun :: [String] -> IO [String]
 nixBuildDryRun jobsExpr = withTime "nix-build --dry-run" $


### PR DESCRIPTION
This allows passing the --add-roots flag to nix-instantiate, which will create GC roots for all derivations involved in the build. Without this we cannot safely run nix gc while we have builds running as the derivations involved in the pipeline might be GC'd (disaster!).

Annoyingly, if we pass this flag to nix-instantiate then it will return not the store paths of the derivations but the gc root paths. So, we resolve these if they are symlinks.