### PR TITLE
Don't fail if we don't have any batches

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -29,7 +29,7 @@ echo "--- :pipeline: Uploading pipeline"
 # Pipeline output is one JSON object per line (batches for large pipelines)
 BATCH_NUM=0
 TOTAL_BATCHES=$(echo "$PIPELINE" | wc -l)
-echo "$PIPELINE" | while IFS= read -r batch; do
+echo -n "$PIPELINE" | while IFS= read -r batch; do
     BATCH_NUM=$((BATCH_NUM + 1))
     if [[ "$TOTAL_BATCHES" -gt 1 ]]; then
         echo "Uploading batch $BATCH_NUM of $TOTAL_BATCHES"


### PR DESCRIPTION
If we had a completely empty pipeline generated, then we still tried to upload but then the buildkite CLI error-ed out since we didn't provide any input.

This was because echo added a trailling newline, which caused the empty output to be an empty line rather than no lines.

The fix is to not add a newline when calling echo