### PR TITLE
Don't try to upload an empty string

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -33,14 +33,19 @@ echo "--- :pipeline: Uploading pipeline"
 # Pipeline output is one JSON object per line (batches for large pipelines)
 BATCH_NUM=0
 TOTAL_BATCHES=$(echo "$PIPELINE" | wc -l)
-echo -n "$PIPELINE" | while IFS= read -r batch; do
-    BATCH_NUM=$((BATCH_NUM + 1))
-    if [[ "$TOTAL_BATCHES" -gt 1 ]]; then
-        echo "Uploading batch $BATCH_NUM of $TOTAL_BATCHES"
-    fi
-    # --no-interpolation: the steps are fully resolved by nix-buildkite (concrete
-    # store paths, sanitized keys), so there is nothing for Buildkite to
-    # interpolate. Leaving it on would try to expand shell syntax like the
-    # collapsed job's ${drvs[@]} array and fail the upload.
-    echo "$batch" | buildkite-agent pipeline upload --no-interpolation
-done
+
+if [ -z "$PIPELINE" ]; then
+    echo "No jobs"
+else
+    echo "$PIPELINE" | while IFS= read -r batch; do
+        BATCH_NUM=$((BATCH_NUM + 1))
+        if [[ "$TOTAL_BATCHES" -gt 1 ]]; then
+            echo "Uploading batch $BATCH_NUM of $TOTAL_BATCHES"
+        fi
+        # --no-interpolation: the steps are fully resolved by nix-buildkite (concrete
+        # store paths, sanitized keys), so there is nothing for Buildkite to
+        # interpolate. Leaving it on would try to expand shell syntax like the
+        # collapsed job's ${drvs[@]} array and fail the upload.
+        echo "$batch" | buildkite-agent pipeline upload --no-interpolation
+    done
+fi


### PR DESCRIPTION
Our previous fix for this bug didn't work. We avoided adding a newline to the last line of output, but that just meant we discarded it.

Instead, let's explicitly check if the input is empty. If so, then there's nothing to do, otherwise we upload each line of output.